### PR TITLE
[bug-fix] correct the font size of the line number in code block

### DIFF
--- a/source/css/highlight.scss
+++ b/source/css/highlight.scss
@@ -48,7 +48,7 @@ $highlight-purple: #cc99cc;
 
 .line-numbers {
     color: #666;
-    font-size: .85rem;
+    font-size: $font-size-code;
 }
 
 article {


### PR DESCRIPTION
Correct the font size of the line number in code block.
Original:
![original](https://cloud.githubusercontent.com/assets/2806164/12505210/b65bb1ce-c11f-11e5-9951-500d31ebc504.png)
After:
![after](https://cloud.githubusercontent.com/assets/2806164/12505230/d8f2bc46-c11f-11e5-8096-40945d9a5c37.png)
