### PR TITLE
Use author instead of title in copyright mark

### DIFF
--- a/layout/base.jade
+++ b/layout/base.jade
@@ -86,7 +86,7 @@ html
           .footer
             - var year = date(new Date(), 'YYYY');
             = '© ' + year + ' '
-            a(href='/', rel='nofollow')= config.title
+            a(href='/', rel='nofollow')= config.author
             = '. Powered by '
             a(rel='nofollow', target='_blank', href='https://hexo.io') Hexo
             = '. Theme '


### PR DESCRIPTION
I thought it would be more appropriate to use the author rather than website title for copyright mark. 
