### PR TITLE
[bug-fix] we should use the official API to get the links to tags and categories

### DIFF
--- a/layout/archive.jade
+++ b/layout/archive.jade
@@ -20,14 +20,14 @@ block main
               ul.tag-box.list-unstyled
                 for category in site.categories.sort('name').toArray()
                   li
-                    a(href=root+'/categories/'+category.name.replace(new RegExp(' ', 'g'), '-'))= category.name
-                      span= category.posts.length
+                    a(href=url_for(category.path))= category.name
+                      span= category.length
             .all-tags
               ul.tag-box.list-unstyled
                 for tag in site.tags.sort('name').toArray()
                   li
-                    a(href=root+'/tags/'+tag.name.replace(new RegExp(' ', 'g'), '-'))= tag.name
-                      span= tag.posts.length
+                    a(href=url_for(tag.path))= tag.name
+                      span= tag.length
 
         .post-archive
             //Use lodash to classify posts. See https://lodash.com/docs#groupBy


### PR DESCRIPTION
The previous fix, which manually replaces characters, would miss some cases. We should use the official API like the post segment below.
